### PR TITLE
moved struct song_info to tinytune.c

### DIFF
--- a/src/tinytune/tinytune.c
+++ b/src/tinytune/tinytune.c
@@ -21,6 +21,19 @@ int16_t sample_buffer[SAMPLE_BUFFER];
 uint8_t sample_buf_clock = SAMPLE_BUFFER - 1;
 uint8_t sample_update_idx = 0;
 
+struct song_info{
+  uint16_t samples_per_tick;
+  uint16_t tick;
+  uint16_t next_tick;
+  uint16_t tick_smp_count;
+  struct song_definition* song_def;
+  uint8_t cur_pattern;
+  uint8_t order_idx;
+  uint16_t pat_idx;
+  bool playing;
+  uint8_t repeats;
+} song_info;
+
 void _setDutyTRI(struct TTVOICE* v, uint8_t duty);
 
 // Gosh.. a mul instruction would be great.

--- a/src/tinytune/tinytune.h
+++ b/src/tinytune/tinytune.h
@@ -180,20 +180,6 @@ struct song_definition {
   const struct TTINSTRUMENT** instruments;
 };
 
-struct {
-  uint16_t samples_per_tick;
-  uint16_t tick;
-  uint16_t next_tick;
-  uint16_t tick_smp_count;
-  struct song_definition* song_def;
-  uint8_t cur_pattern;
-  uint8_t order_idx;
-  uint16_t pat_idx;
-  bool playing;
-  uint8_t repeats;
-} song_info;
-
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR will fix the following compiler error with Arduino 1.8.13 for Win10 (and Mac OS X):

tinytune.h:194:3: warning: type of 'song_info' does not match original declaration [-Wlto-type-mismatch]
} song_info;